### PR TITLE
Fixed GarageDoor/GarageDoormat

### DIFF
--- a/Assets/Script/GarageDoorCollider.cs
+++ b/Assets/Script/GarageDoorCollider.cs
@@ -12,6 +12,7 @@ public class GarageDoorCollider : MonoBehaviour
     {
         garageDoor = gameObject;
         garageDoormat = GameObject.Find("Garage Doormat");
+        garageDoormat.SetActive(false);
         
     }
 

--- a/Assets/Script/GarageDoormatCollider.cs
+++ b/Assets/Script/GarageDoormatCollider.cs
@@ -17,9 +17,6 @@ public class GarageDoormatCollider : MonoBehaviour {
         GarageDoormat = GameObject.Find("Garage Doormat");
         GarageBrickWall = GameObject.Find("Garage Brick Walls");
         GarageRoof = GameObject.Find("Garage Roof");
-
-        GarageDoormat.SetActive(false);
-
     }
 
     void OnTriggerEnter2D(Collider2D col)


### PR DESCRIPTION
Changed to deactivate the doormat AFTER finding it in the GarageDoor script, and not in the doormat's constructor.

May want to just make the GameObject references public so that you can manage which door & doormat are controlled by which mechanisms from within the editor by just dragging/dropping.

That or some parent/child scheme so that you can just clone an old one within Unity and it'll function within its family, without searching the entire scene multiple times per door mechanism.